### PR TITLE
Remove requirement for exceptions to contain an action 

### DIFF
--- a/src/R.Scheduler.Persistence/SqlServerStore.cs
+++ b/src/R.Scheduler.Persistence/SqlServerStore.cs
@@ -114,7 +114,7 @@ namespace R.Scheduler.Persistence
                 count = 1000;
             }
 
-            string sql = string.Format(@"SELECT TOP {0} a.*, m.[ID] as 'JOB_ID' FROM [RSCHED_AUDIT_HISTORY] a, [RSCHED_JOB_ID_KEY_MAP] m WHERE a.[EXECUTION_EXCEPTION] <> '' AND a.[ACTION] = 'JobWasExecuted' AND a.[JOB_NAME] = m.[JOB_NAME] AND a.[JOB_GROUP] = m.[JOB_GROUP] order by a.[TIME_STAMP] DESC", count);
+            string sql = string.Format(@"SELECT TOP {0} a.*, m.[ID] as 'JOB_ID' FROM [RSCHED_AUDIT_HISTORY] a, [RSCHED_JOB_ID_KEY_MAP] m WHERE a.[EXECUTION_EXCEPTION] <> '' AND a.[JOB_NAME] = m.[JOB_NAME] AND a.[JOB_GROUP] = m.[JOB_GROUP] order by a.[TIME_STAMP] DESC", count);
 
             IEnumerable<AuditLog> retval = GetAuditLogs(sql);
 


### PR DESCRIPTION
Change GetErroredJobs to return all audit messages containing an exception to support custom audit entries with exceptions. This allows for asynchronous jobs where the execution to trigger an external source succeeds (such as calling a web endpoint that returns 200) but errors at later date with custom audit message such as "JobResultFailed" perhaps because of user failing to respond or another system timing out.